### PR TITLE
Create publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,22 +38,10 @@ jobs:
           rm -rf che-docs/Jenkinsfile che-docs/push-to-eclipse-repository.sh che-docs/.git
           cp -R che-docs/* che-website/build/che
           
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+          
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: che-website/build/che
-
-  deploy:
-    name: "Deploy to Pages"
-    needs: build
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./che-website/build/che
+          publish_branch: publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,55 @@
+name: publish
+on:
+  - push
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout local code
+        uses: actions/checkout@v4
+        
+      - name: Checkout che-website main branch
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-che/che-website
+          ref: main
+          path: che-website
+      - name: Install packages to build che-website
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: che-website
+      - name: Build che-website to website/build/che
+        run: yarn build
+        working-directory: che-website
+
+      - name: Checkout che-docs publication branch
+        uses: actions/checkout@v4
+        with:
+          repository: eclipse-che/che-docs
+          ref: publication
+          path: che-docs  
+      - name: Copy che-docs to website/buil/che
+        run: |
+          rm -rf che-docs/Jenkinsfile che-docs/push-to-eclipse-repository.sh che-docs/.git
+          cp -R che-docs/* che-website/build/che
+          
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: che-website/build/che
+
+  deploy:
+    name: "Deploy to Pages"
+    needs: build
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,3 +45,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./che-website/build/che
           publish_branch: publish
+          force_orphan: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,10 @@
 name: publish
 on:
   - push
+  - schedule:
+    - cron '30 5,17 * * *'
+  - workflow_dispatch
+  
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
This is one way to put all the static website content (website and docs) into a branch.

This worklow will run on schedule, daily at 5:30 and 17:30, and might be run manually, and do following steps:

1. Get che-website sources.
2. Build che-website static site.
3. Get che-docs content publication branch.
4. Copy docs to the built website.
5. Push the results to the `publish` branch.

It requires GITHUB_TOKEN to have read and write permissions. See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

Followup steps:

1. Eclipse admin should point the Eclipse publication tooling to the `publish` branch.
2. For clarity, you might want to clean up this repository: remove any content that is not this workflow from the `main` branch.
3. For clarity, you might want to clean up the `che-docs` repository: remove the `Jenkinsfile` and `push-to-eclipse-repository.sh` files and any references to them.