### PR TITLE
Fix syntax errors in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,9 @@
 name: publish
 on:
-  - push
-  - schedule:
-    - cron '30 5,17 * * *'
-  - workflow_dispatch
+  push:
+  schedule:
+    - cron: '30 5,17 * * *'
+  workflow_dispatch:
   
 jobs:
   build:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 name: publish
 on:
   push:
+    branches:
+      - main
   schedule:
     - cron: '30 5,17 * * *'
   workflow_dispatch:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     branches:
-      - main
+      - master
   schedule:
     - cron: '30 5,17 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Also:
- limit `push` trigger only to default master branch pushes