### PR TITLE
chore: keep history in the publish branch - required for website update

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,4 +47,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./che-website/build/che
           publish_branch: publish
-          force_orphan: true
+          force_orphan: false


### PR DESCRIPTION
This change will enable saving history for publish branch, as it seems like is what's needed for the Website workflow to detect updates - https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4535#note_2134707