### PR TITLE
fix: make this workflow re-usable

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: '30 5,17 * * *'
   workflow_dispatch:
+  workflow_call:
   
 jobs:
   build:


### PR DESCRIPTION
add 'workflow_call' trigger type for this workflow, to be [reusable by che-docs workflow](https://github.com/eclipse-che/che-docs/actions/runs/12958481415)