### PR TITLE
use container for the build job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-22.04
+    container: node:18
     steps:
       - name: Checkout local code
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix failing publish job - now use container with node 18 to build che-website

(tested it in a simple pipeline that built it without pushing)
https://github.com/eclipse-che/che-website-publish/actions/runs/15826544194/job/44608113698